### PR TITLE
Fix JH image build.

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -5,7 +5,7 @@ check:
   - thoth-build
 build:
   build-stratergy: Source
-  build_source_script: "image:///opt/app-root/builder"
+  build-source-script: "image:///opt/app-root/builder"
   base-image: quay.io/thoth-station/s2i-custom-notebook:latest
   custom-tag: latest
   registry: quay.io


### PR DESCRIPTION
## Description

Fix image build for Jupyterhub by using the `build-source-script` key in .aicoe-ci.yaml

see https://github.com/operate-first/odh-moc-support/issues/17 for details

## This introduces a breaking change

- [ ] Yes
- [x] No

